### PR TITLE
Add Jest framework with basic test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,15 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.17.1"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('App', () => {
+  it('GET / responds with Hello world', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Hello world' });
+  });
+});


### PR DESCRIPTION
## Summary
- install Jest and Supertest
- create `/tests` directory and add a simple health check test
- add `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850acee11688324b5f79cfa2a38ac64