### PR TITLE
Update README with install and start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # GoStack_GoBarber
+
+Simple Express server example used in the GoStack Bootcamp.
+
+## Installation
+
+Install the project dependencies with either Yarn or npm:
+
+```bash
+yarn install
+# or
+npm install
+```
+
+## Running the server
+
+Start the application with Node or via the npm script:
+
+```bash
+node src/server.js
+# or
+npm start
+```
+
+The server listens on port **3333** by default.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "start": "node src/server.js"
+  },
   "dependencies": {
     "express": "^4.17.1"
   }


### PR DESCRIPTION
## Summary
- document basic setup and running the server
- add npm `start` script so `npm start` works

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `yarn install` *(fails: tunneling socket could not be established)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6850acc959848324af21d7790f271755