### PR TITLE
Update README with setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # GoStack_GoBarber
+
+A simple Express server used in the GoStack Bootcamp.
+
+## Getting Started
+
+Install the dependencies:
+
+```bash
+yarn install
+# or
+npm install
+```
+
+Start the server:
+
+```bash
+node src/server.js
+# or
+npm start
+```
+
+The application listens on port `3333` by default.
+

--- a/package.json
+++ b/package.json
@@ -5,5 +5,9 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.17.1"
+  },
+  "scripts": {
+    "start": "node src/server.js"
   }
 }
+


### PR DESCRIPTION
## Summary
- document how to set up and run the server
- add `npm start` script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850acbf01f88324bdacd2b3adc5a8e2